### PR TITLE
Remove landing page and redirect directly to login

### DIFF
--- a/apps/web/app/(landing)/page.tsx
+++ b/apps/web/app/(landing)/page.tsx
@@ -1,25 +1,8 @@
 import type { Metadata } from "next";
-import { HeroHome } from "@/app/(landing)/home/Hero";
-import { FeaturesHome } from "@/app/(landing)/home/Features";
-import { Privacy } from "@/app/(landing)/home/Privacy";
-import { Testimonials } from "@/app/(landing)/home/Testimonials";
-import { PricingLazy } from "@/app/(app)/premium/PricingLazy";
-import { FAQs } from "@/app/(landing)/home/FAQs";
-import { CTA } from "@/app/(landing)/home/CTA";
-import { BasicLayout } from "@/components/layouts/BasicLayout";
+import { redirect } from "next/navigation";
 
 export const metadata: Metadata = { alternates: { canonical: "/" } };
 
 export default function Home() {
-  return (
-    <BasicLayout>
-      <HeroHome />
-      <Testimonials />
-      <Privacy />
-      <FeaturesHome />
-      <PricingLazy className="pb-32" />
-      <FAQs />
-      <CTA />
-    </BasicLayout>
-  );
+  redirect("/login");
 }


### PR DESCRIPTION
## Summary

This PR removes the landing page/sign-up flow and redirects users directly to the login page with Google/Microsoft authentication options.

## Changes Made

- **Modified `apps/web/app/(landing)/page.tsx`**: Replaced the entire marketing landing page content with a simple redirect to `/login`
- **Streamlined user flow**: Users now go straight to authentication instead of seeing marketing content first
- **Preserved existing functionality**: All existing login functionality with Google and Microsoft OAuth remains intact

## Technical Details

- Used Next.js `redirect()` function for server-side redirect
- Maintains the existing route structure and authentication flow
- No changes to the actual login page or authentication logic

## Testing

- ✅ Verified redirect works correctly from root URL (`/`) to `/login`
- ✅ Confirmed login page displays properly with Google and Microsoft sign-in options
- ✅ Development server runs without errors
- ✅ Environment variables configured and validated

## Impact

- **User Experience**: Eliminates friction by removing the landing page step
- **Conversion**: Users can authenticate immediately without additional clicks
- **Maintenance**: Reduces complexity by removing marketing content from the main flow

This change aligns with the goal of streamlining the user onboarding process by removing the intermediate landing page step.

@TradieMate can click here to [continue refining the PR](https://app.all-hands.dev/conversations/71c29458c3d040428398104dae732ed5)